### PR TITLE
GitHub Labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ This repository contains documents describing everything a contributor of Apache
 
 ## Topics
 
+### Process
+
+- [GitHub Labels](github-labels.md)

--- a/github-labels.md
+++ b/github-labels.md
@@ -12,7 +12,7 @@ The following defines the label names, label description and label color in use:
 
 The [default labels](https://help.github.com/articles/about-labels/#using-default-labels) created with new repositories offer a good baseline:
 
-- <div style="background-color:#d73a4a; padding:3px 8px; border-radius: 3px; display:inline;">bug</div>: Something isn't working
+- <div color="#d73a4a" style="background-color:#d73a4a; padding:3px 8px; border-radius: 3px; display:inline;">bug</div>: Something isn't working
 - <div style="background-color:#cfd3d7; padding:3px 8px; border-radius: 3px; display:inline;">duplicate</div>: This issue or pull request already exists
 - <div style="background-color:#a2eeef; padding:3px 8px; border-radius: 3px; display:inline;">enhancement</div>: ~~New feature or request~~ Changes to existing code
 - <div style="background-color:#7057ff; padding:3px 8px; border-radius: 3px; display:inline;">good first issue</div>: Good for newcomers

--- a/github-labels.md
+++ b/github-labels.md
@@ -87,7 +87,7 @@ P0: critical
 
 -->
 
-## Distribute GitHub Templates to all repositories
+## Distribute GitHub Labels to multiple repositories
 
 TODO
 <!--

--- a/github-labels.md
+++ b/github-labels.md
@@ -17,7 +17,7 @@ The [default labels](https://help.github.com/articles/about-labels/#using-defaul
 - ![#a2eeef](https://placehold.it/20/a2eeef/000000?text=+) `enhancement`: ~~New feature or request~~ Changes to existing code
 - ![#7057ff](https://placehold.it/20/7057ff/000000?text=+) `good first issue`: Good for newcomers
 - ![#008672](https://placehold.it/20/008672/000000?text=+) `help wanted`: Extra attention is needed
-- ![#e4e669](https://placehold.it/20/d73a4a/000000?text=+) `invalid`: This doesn't seem right
+- ![#e4e669](https://placehold.it/20/e4e669/000000?text=+) `invalid`: This doesn't seem right
 - ![#d876e3](https://placehold.it/20/d876e3/000000?text=+) `question`: Further information is requested
 - ![#ffffff](https://placehold.it/20/ffffff/000000?text=+) `wontfix`: This will not be worked on
 

--- a/github-labels.md
+++ b/github-labels.md
@@ -1,0 +1,120 @@
+# GitHub Labels
+
+Apache Cordova uses [Github Issues](github-issues.md) for issue tracking and [GitHub Pull Requests](github-pull-requests.md) for code changes and contributions. Issues and Pull Requests use [labels](https://help.github.com/articles/about-labels/) for organization and categorization.
+
+Cordova does _not_ use labels for version, milestone or release tracking. [GitHub Milestones](github-milestones.md) are used for that.
+
+## Apache Cordova GitHub Labels
+
+The following defines the label names, label description and label color in use:
+
+### Default labels
+
+The [default labels](https://help.github.com/articles/about-labels/#using-default-labels) created with new repositories offer a good baseline:
+
+- <span style="background-color:#d73a4a; padding:3px; border-radius: 3px;">`bug`</span>: Something isn't working
+- <span style="background-color:#cfd3d7; padding:3px; border-radius: 3px;">`duplicate`</span>: This issue or pull request already exists
+- <span style="background-color:#a2eeef; padding:3px; border-radius: 3px;">`enhancement`</span>: ~~New feature or request~~ Changes to existing code
+- <span style="background-color:#7057ff; padding:3px; border-radius: 3px;">`good first issue`</span>: Good for newcomers
+- <span style="background-color:#008672; padding:3px; border-radius: 3px;">`help wanted`</span>: Extra attention is needed
+- <span style="background-color:#e4e669; padding:3px; border-radius: 3px;">`invalid`</span>: This doesn't seem right
+- <span style="background-color:#d876e3; padding:3px; border-radius: 3px;">`question`</span>: Further information is requested
+- <span style="background-color:#ffffff; padding:3px; border-radius: 3px;">`wontfix`</span>: This will not be worked on
+
+The label names `good first issue` and `help wanted` have [special meaning](https://help.github.com/articles/helping-new-contributors-find-your-project-with-labels/) on GitHub.
+
+#### Changes to default labels
+
+The list above has some ~~strike through~~ text. These are our changes to the default labels, so they don't clash with out custom labels below.
+
+### Custom labels
+
+- <span style="background-color:#0e8a16; padding:3px; border-radius: 3px;">`feature`</span>: New functionality that requires new code
+- <span style="background-color:#1d76db; padding:3px; border-radius: 3px;">`discussion`</span>: Creator is open to suggestions or wants to discuss how something should be implemented
+- <span style="background-color:#ccc; padding:3px; border-radius: 3px;">`support`</span>: Support questions that want to understand how something works, need help debugging their individual problem etc. are closed and tagged with this label.
+
+#### Plugin repositories
+
+For plugin repositories it makes sense to categorize Issues - e.g. a bug report or feature request - or Pull Requests by its platform:
+
+- <span style="background-color:#c5def5; padding:3px; border-radius: 3px;">`platform: ios`</span>
+- <span style="background-color:#c2e0c6; padding:3px; border-radius: 3px;">`platform: android`</span>
+- <span style="background-color:#fef2c0; padding:3px; border-radius: 3px;">`platform: browser`</span>
+- <span style="background-color:#d4c5f9; padding:3px; border-radius: 3px;">`platform: windows`</span>
+
+<!--
+### Possible future labels
+
+A collection of labels that might be useful for Cordova in the future, with e.g. some automation in place:
+
+```
+waiting-for-information: Requested more information from user and waiting for reply.
+confirmed: To indicate a bug has been replicated and a PR fixing the problem should be created.
+has-pr: Issues that already have a PR that is waiting to get reviewed/merged/released.
+work-in-progress: Someone is currently working on this Pull Request.
+
+triage
+needs investigation
+needs info
+needs reply 
+cannot reproduce 
+
+status: auto-closed
+status: waiting-for-reply
+status: needs-attention
+status: on-hold
+status: blocked
+
+status: included-in-next-release
+status: released
+
+type: code-improvement
+type: documentation
+
+effort: low
+effort: moderate
+effort: high
+
+priority: low
+priority: high
+
+P4: nice to have
+P3: important
+P2: required
+P1: urgent
+P0: critical
+```
+
+-->
+
+## Distribute GitHub Templates to all repositories
+
+TODO
+<!--
+Pseudocode:
+Go through all repositories
+  Go through list of label definitions
+    If label already exists
+      Update description and color
+      # This is important as the color and descriptions mentioned above are pretty new, so most of Cordova's repositories are configured with an older color set and without descriptions.
+    If label does not exist
+      Create label with description and color
+  If labels exist that are not part of label definitions
+    Output details for manual handling
+      - name, description, color
+      - number of issues
+
+Existing Alternatives:
+- http://www.dorukdestan.com/github-label-manager/ 
+  - https://medium.com/@dtinth/how-to-copy-github-labels-from-one-project-to-another-1857adc73e0f
+  - terrible security practices as basic auth is used
+- https://github.com/HewlettPackard/yoda/blob/master/docs/MANUAL.md#label-manager
+  https://hewlettpackard.github.io/yoda/yoda-label-manager.html
+- https://gist.github.com/symm/ba69f2b715558c61b1a2 
+  - Could be used for a simple PHP script
+- https://github.com/BlueAcornInc/github-label-manager
+  uses https://github.com/jasonbellamy/git-label
+- https://github.com/himynameisdave/git-labelmaker
+  uses https://github.com/jasonbellamy/git-label
+
+-->

--- a/github-labels.md
+++ b/github-labels.md
@@ -12,14 +12,14 @@ The following defines the label names, label description and label color in use:
 
 The [default labels](https://help.github.com/articles/about-labels/#using-default-labels) created with new repositories offer a good baseline:
 
-- <div color="#d73a4a" style="background-color:#d73a4a; padding:3px 8px; border-radius: 3px; display:inline;">bug</div>: Something isn't working
-- <div style="background-color:#cfd3d7; padding:3px 8px; border-radius: 3px; display:inline;">duplicate</div>: This issue or pull request already exists
-- <div style="background-color:#a2eeef; padding:3px 8px; border-radius: 3px; display:inline;">enhancement</div>: ~~New feature or request~~ Changes to existing code
-- <div style="background-color:#7057ff; padding:3px 8px; border-radius: 3px; display:inline;">good first issue</div>: Good for newcomers
-- <div style="background-color:#008672; padding:3px 8px; border-radius: 3px; display:inline;">help wanted</div>: Extra attention is needed
-- <div style="background-color:#e4e669; padding:3px 8px; border-radius: 3px; display:inline;">invalid</div>: This doesn't seem right
-- <div style="background-color:#d876e3; padding:3px 8px; border-radius: 3px; display:inline;">question</div>: Further information is requested
-- <div style="background-color:#ffffff; padding:3px 8px; border-radius: 3px; display:inline;">wontfix</div>: This will not be worked on
+- ![#f03c15](https://placehold.it/20/d73a4a/000000?text=+) `bug`: Something isn't working
+- ![#cfd3d7](https://placehold.it/20/cfd3d7/000000?text=+) `duplicate`: This issue or pull request already exists
+- ![#a2eeef](https://placehold.it/20/a2eeef/000000?text=+) `enhancement`: ~~New feature or request~~ Changes to existing code
+- ![#7057ff](https://placehold.it/20/7057ff/000000?text=+) `good first issue`: Good for newcomers
+- ![#008672](https://placehold.it/20/008672/000000?text=+) `help wanted`: Extra attention is needed
+- ![#e4e669](https://placehold.it/20/d73a4a/000000?text=+) `invalid`: This doesn't seem right
+- ![#d876e3](https://placehold.it/20/d876e3/000000?text=+) `question`: Further information is requested
+- ![#ffffff](https://placehold.it/20/ffffff/000000?text=+) `wontfix`: This will not be worked on
 
 The label names `good first issue` and `help wanted` have [special meaning](https://help.github.com/articles/helping-new-contributors-find-your-project-with-labels/) on GitHub.
 
@@ -29,18 +29,18 @@ The list above has some ~~strike through~~ text. These are our changes to the de
 
 ### Custom labels
 
-- <div style="background-color:#0e8a16; padding:3px 8px; border-radius: 3px; display:inline;">feature</div>: New functionality that requires new code
-- <div style="background-color:#1d76db; padding:3px 8px; border-radius: 3px; display:inline;">discussion</div>: Creator is open to suggestions or wants to discuss how something should be implemented
-- <div style="background-color:#ccc; padding:3px 8px; border-radius: 3px; display:inline;">support</div>: Support questions that want to understand how something works, need help debugging their individual problem etc. are closed and tagged with this label.
+- ![#0e8a16](https://placehold.it/20/0e8a16/000000?text=+) `feature`: New functionality that requires new code
+- ![#1d76db](https://placehold.it/20/1d76db/000000?text=+) `discussion`: Creator is open to suggestions or wants to discuss how something should be implemented
+- ![#ccc](https://placehold.it/20/ccc/000000?text=+) `support`: Support questions that want to understand how something works, need help debugging their individual problem etc. are closed and tagged with this label.
 
 #### Plugin repositories
 
 For plugin repositories it makes sense to categorize Issues - e.g. a bug report or feature request - or Pull Requests by its platform:
 
-- <div style="background-color:#c5def5; padding:3px 8px; border-radius: 3px; display:inline;">platform: ios</div>
-- <div style="background-color:#c2e0c6; padding:3px 8px; border-radius: 3px; display:inline;">platform: android</div>
-- <div style="background-color:#fef2c0; padding:3px 8px; border-radius: 3px; display:inline;">platform: browser</div>
-- <div style="background-color:#d4c5f9; padding:3px 8px; border-radius: 3px; display:inline;">platform: windows</div>
+- ![#c5def5](https://placehold.it/20/c5def5/000000?text=+) `platform: ios`
+- ![#c2e0c6](https://placehold.it/20/c2e0c6/000000?text=+) `platform: android`
+- ![#fef2c0](https://placehold.it/20/fef2c0/000000?text=+) `platform: browser`
+- ![#d4c5f9](https://placehold.it/20/d4c5f9/000000?text=+) `platform: windows`
 
 <!--
 ### Possible future labels

--- a/github-labels.md
+++ b/github-labels.md
@@ -12,14 +12,14 @@ The following defines the label names, label description and label color in use:
 
 The [default labels](https://help.github.com/articles/about-labels/#using-default-labels) created with new repositories offer a good baseline:
 
-- <span style="background-color:#d73a4a; padding:3px; border-radius: 3px;">`bug`</span>: Something isn't working
-- <span style="background-color:#cfd3d7; padding:3px; border-radius: 3px;">`duplicate`</span>: This issue or pull request already exists
-- <span style="background-color:#a2eeef; padding:3px; border-radius: 3px;">`enhancement`</span>: ~~New feature or request~~ Changes to existing code
-- <span style="background-color:#7057ff; padding:3px; border-radius: 3px;">`good first issue`</span>: Good for newcomers
-- <span style="background-color:#008672; padding:3px; border-radius: 3px;">`help wanted`</span>: Extra attention is needed
-- <span style="background-color:#e4e669; padding:3px; border-radius: 3px;">`invalid`</span>: This doesn't seem right
-- <span style="background-color:#d876e3; padding:3px; border-radius: 3px;">`question`</span>: Further information is requested
-- <span style="background-color:#ffffff; padding:3px; border-radius: 3px;">`wontfix`</span>: This will not be worked on
+- <div style="background-color:#d73a4a; padding:3px 8px; border-radius: 3px; display:inline;">bug</div>: Something isn't working
+- <div style="background-color:#cfd3d7; padding:3px 8px; border-radius: 3px; display:inline;">duplicate</div>: This issue or pull request already exists
+- <div style="background-color:#a2eeef; padding:3px 8px; border-radius: 3px; display:inline;">enhancement</div>: ~~New feature or request~~ Changes to existing code
+- <div style="background-color:#7057ff; padding:3px 8px; border-radius: 3px; display:inline;">good first issue</div>: Good for newcomers
+- <div style="background-color:#008672; padding:3px 8px; border-radius: 3px; display:inline;">help wanted</div>: Extra attention is needed
+- <div style="background-color:#e4e669; padding:3px 8px; border-radius: 3px; display:inline;">invalid</div>: This doesn't seem right
+- <div style="background-color:#d876e3; padding:3px 8px; border-radius: 3px; display:inline;">question</div>: Further information is requested
+- <div style="background-color:#ffffff; padding:3px 8px; border-radius: 3px; display:inline;">wontfix</div>: This will not be worked on
 
 The label names `good first issue` and `help wanted` have [special meaning](https://help.github.com/articles/helping-new-contributors-find-your-project-with-labels/) on GitHub.
 
@@ -29,18 +29,18 @@ The list above has some ~~strike through~~ text. These are our changes to the de
 
 ### Custom labels
 
-- <span style="background-color:#0e8a16; padding:3px; border-radius: 3px;">`feature`</span>: New functionality that requires new code
-- <span style="background-color:#1d76db; padding:3px; border-radius: 3px;">`discussion`</span>: Creator is open to suggestions or wants to discuss how something should be implemented
-- <span style="background-color:#ccc; padding:3px; border-radius: 3px;">`support`</span>: Support questions that want to understand how something works, need help debugging their individual problem etc. are closed and tagged with this label.
+- <div style="background-color:#0e8a16; padding:3px 8px; border-radius: 3px; display:inline;">feature</div>: New functionality that requires new code
+- <div style="background-color:#1d76db; padding:3px 8px; border-radius: 3px; display:inline;">discussion</div>: Creator is open to suggestions or wants to discuss how something should be implemented
+- <div style="background-color:#ccc; padding:3px 8px; border-radius: 3px; display:inline;">support</div>: Support questions that want to understand how something works, need help debugging their individual problem etc. are closed and tagged with this label.
 
 #### Plugin repositories
 
 For plugin repositories it makes sense to categorize Issues - e.g. a bug report or feature request - or Pull Requests by its platform:
 
-- <span style="background-color:#c5def5; padding:3px; border-radius: 3px;">`platform: ios`</span>
-- <span style="background-color:#c2e0c6; padding:3px; border-radius: 3px;">`platform: android`</span>
-- <span style="background-color:#fef2c0; padding:3px; border-radius: 3px;">`platform: browser`</span>
-- <span style="background-color:#d4c5f9; padding:3px; border-radius: 3px;">`platform: windows`</span>
+- <div style="background-color:#c5def5; padding:3px 8px; border-radius: 3px; display:inline;">platform: ios</div>
+- <div style="background-color:#c2e0c6; padding:3px 8px; border-radius: 3px; display:inline;">platform: android</div>
+- <div style="background-color:#fef2c0; padding:3px 8px; border-radius: 3px; display:inline;">platform: browser</div>
+- <div style="background-color:#d4c5f9; padding:3px 8px; border-radius: 3px; display:inline;">platform: windows</div>
 
 <!--
 ### Possible future labels


### PR DESCRIPTION
This PR explains how GitHub labels are used for Apache Cordova and what labels are in use.

It is the result of this mailing list discussion: https://lists.apache.org/thread.html/87c4003e22bf41bc08f333ddd632163bbdfbb2e9fc7801689e7bd006@%3Cdev.cordova.apache.org%3E

To be able to see the colors for the labels, use the "View" button on the Markdown file in "Files changed" view. (I had to abuse a placeholder image service to be able to display some colored blocks on GitHub Markdown view.)

Besides the obvious text for the documentation, it also includes two invisible sections (via HTML comments) that include a collection of "Possible future labels" and thoughts and research about the tool we will need to "Distribute GitHub Labels to all repositories".

---

Please leave an "Approve" review if you are ok with the current state to be merged.
We can and will of course iterate on the labels with use over time, so this doesn't have to be perfect now.