### PR TITLE
Add contributing file for all repositories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+-->
+
+# Contributing to Apache Cordova
+
+Anyone can contribute to Cordova. And we need your contributions.
+
+There are multiple ways to contribute: report bugs, improve the docs, and
+contribute code.
+  
+For instructions on this, start with the
+[contribution overview](http://cordova.apache.org/contribute/).
+
+The details are explained there, but the important items are:
+ - Check for Github issues that corresponds to your contribution and link or create them if necessary.
+ - Run the tests so your patch doesn't break existing functionality.
+
+We look forward to your contributions!
+


### PR DESCRIPTION
See discussion on[ mailing list](https://lists.apache.org/thread.html/r3c95cf9ebb488694f02aa3accd1f7436dd9cfd8a8dbdc2af4db9cf3a%40%3Cdev.cordova.apache.org%3E)

I took the file from Android and edited the sentence about Jira to Github. The purpose of this file should be to invite potential contributors and link to our contact channels and contributing docs.

I thinks it's best to keep the detailed and longer guide on [the website here](https://cordova.apache.org/contribute/contribute_guidelines.html) to make updating it easier.

We should do our best to make this easy and not put people of from contributing.

Once this PR gets positive response I will merge it and commit this file to all repositories.