### PR TITLE
cleanup: remove trailing spaces

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -24,10 +24,10 @@ We very much prefer issues created by using one of these templates.
 
 
 ### Version information
-<!-- 
+<!--
 What are relevant versions you are using?
 For example:
-Cordova: Cordova CLI, Cordova Platforms, Cordova Plugins 
+Cordova: Cordova CLI, Cordova Platforms, Cordova Plugins
 Other Frameworks: Ionic Framework and CLI version
 Operating System, Android Studio, Xcode etc.
 -->

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -32,10 +32,10 @@ about: If something isn't working as expected.
 
 
 ### Version information
-<!-- 
+<!--
 What are relevant versions you are using?
 For example:
-Cordova: Cordova CLI, Cordova Platforms, Cordova Plugins 
+Cordova: Cordova CLI, Cordova Platforms, Cordova Plugins
 Other Frameworks: Ionic Framework and CLI version
 Operating System, Android Studio, Xcode etc.
 -->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -12,17 +12,17 @@ about: A suggestion for a new functionality
 
 
 ## Feature Description
-<!-- 
+<!--
 Describe your feature request in detail
 Please provide any code examples or screenshots of what this feature would look like
-Are there any drawbacks? Will this break anything for existing users? 
+Are there any drawbacks? Will this break anything for existing users?
 -->
 
 
 
 ## Alternatives or Workarounds
-<!-- 
-Describe alternatives or workarounds you are currently using 
+<!--
+Describe alternatives or workarounds you are currently using
 Are there ways to do this with existing functionality?
 -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ Anyone can contribute to Cordova. And we need your contributions.
 
 There are multiple ways to contribute: report bugs, improve the docs, and
 contribute code.
-  
+
 For instructions on this, start with the
 [contribution overview](http://cordova.apache.org/contribute/).
 

--- a/create-reproduction.md
+++ b/create-reproduction.md
@@ -4,7 +4,7 @@ When reporting an issue or bug for any of the Apache Cordova packages, it is hel
 
 ## Why?
 
-The goal of the reproduction repository is to replicate the bug in a minimal project that contains only the necessary platforms, libraries, and plugins to reproduce the bug. 
+The goal of the reproduction repository is to replicate the bug in a minimal project that contains only the necessary platforms, libraries, and plugins to reproduce the bug.
 
 For a Cordova maintainer it can be a lot of work to reproduce your specific issue as there are many aspects to your  working environment and source code. By creating a reproduction repository, you can prodive _all_ useful information to the maintainer and make this process much easier and faster.
 
@@ -17,7 +17,7 @@ The steps below show how to create a reproduction repository on GitHub. (Any pub
 ### TLDR:
 
 - Create a new Cordova project,
-- implement a reproduction of your problem, 
+- implement a reproduction of your problem,
 - put the project on Github,
 - and post the link to the repository in your issue.
 
@@ -25,7 +25,7 @@ The steps below show how to create a reproduction repository on GitHub. (Any pub
 
 1. [Create a new repository](https://github.com/new) on GitHub
 1. Insert a `Repository name`
-1. Select `Public` to make the repository publicly accessible  
+1. Select `Public` to make the repository publicly accessible
     **IMPORTANT:** Do not check "Initialize this repository with a README"
 1. Click `Create repository`
 

--- a/deprecation.md
+++ b/deprecation.md
@@ -7,7 +7,7 @@
 
 ### 1. Vote
 
-Similar to other important decisions, Apache Cordova uses a [voting process](https://www.apache.org/foundation/how-it-works.html#decision-making) on deprecations and archiving of components. If you intend to deprecate or archive a component or repository, send an email to the [appropriate mailing list](https://cordova.apache.org/contact/) describing the intended action and start a vote on it.  
+Similar to other important decisions, Apache Cordova uses a [voting process](https://www.apache.org/foundation/how-it-works.html#decision-making) on deprecations and archiving of components. If you intend to deprecate or archive a component or repository, send an email to the [appropriate mailing list](https://cordova.apache.org/contact/) describing the intended action and start a vote on it.
 
 Only proceed if the vote succeeds.
 
@@ -21,7 +21,7 @@ Add the [Deprecation Notice Template](#deprecation-notice) to the `README.md` of
 
 ### 4. Archiving only: Close Issues and Pull Requests
 
-As archiving will make Issues and Pull Requests read only, it is common and [suggested by GitHub](https://help.github.com/articles/about-archiving-repositories/) to clean up issues and pull requests before archiving a repository. If there are open issues or PRs with the component's repository, please close them with the [suggested Issue and Pull Request closing text](#suggested-issue-and-pull-request-closing-text) or similar. 
+As archiving will make Issues and Pull Requests read only, it is common and [suggested by GitHub](https://help.github.com/articles/about-archiving-repositories/) to clean up issues and pull requests before archiving a repository. If there are open issues or PRs with the component's repository, please close them with the [suggested Issue and Pull Request closing text](#suggested-issue-and-pull-request-closing-text) or similar.
 
 ### 5. Request GitHub repository changes from Apache INFRA
 
@@ -36,8 +36,8 @@ For archiving:
 
 1. Make sure the deprecation notice is in `README.md` and contains all information.
 1. Make sure there are no more open Issues and Pull Requests for this repository.
-1. [Open an issue](https://issues.apache.org/jira/browse/INFRA) and request that   
-  a) the repository description is prefixed with `[DEPRECATED] ` and   
+1. [Open an issue](https://issues.apache.org/jira/browse/INFRA) and request that
+  a) the repository description is prefixed with `[DEPRECATED] ` and
   b) the repository is archived on GitHub.
 
 ### 6. Announce

--- a/github-labels.md
+++ b/github-labels.md
@@ -57,8 +57,8 @@ work-in-progress: Someone is currently working on this Pull Request.
 triage
 needs investigation
 needs info
-needs reply 
-cannot reproduce 
+needs reply
+cannot reproduce
 
 status: auto-closed
 status: waiting-for-reply
@@ -108,12 +108,12 @@ Go through all repositories
       - number of issues
 
 Existing Alternatives:
-- http://www.dorukdestan.com/github-label-manager/ 
+- http://www.dorukdestan.com/github-label-manager/
   - https://medium.com/@dtinth/how-to-copy-github-labels-from-one-project-to-another-1857adc73e0f
   - terrible security practices as basic auth is used
 - https://github.com/HewlettPackard/yoda/blob/master/docs/MANUAL.md#label-manager
   https://hewlettpackard.github.io/yoda/yoda-label-manager.html
-- https://gist.github.com/symm/ba69f2b715558c61b1a2 
+- https://gist.github.com/symm/ba69f2b715558c61b1a2
   - Could be used for a simple PHP script
 - https://github.com/BlueAcornInc/github-label-manager
   uses https://github.com/jasonbellamy/git-label

--- a/github-project-boards.md
+++ b/github-project-boards.md
@@ -25,9 +25,9 @@ For Pull Requests we track their "review and merge progress" on project boards:
 
 #### Columns
 
-- Pull Requests start in the "New PR / Untriaged" column (added manually by using the "Add Card" functionality) 
-- They can then be sorted by a maintainer into columns according to their "review" readiness ("Blocked: Work in Progress", "Blocked: Conflict", "Blocked: Tests failing" or "Ready for Review").  
-- On review, merge, close etc. they are moved to other columns by automation ("Pending Approval", "Approved, waiting for Merge", "Merged, waiting for Release", "Closed/Abandoned").  
+- Pull Requests start in the "New PR / Untriaged" column (added manually by using the "Add Card" functionality)
+- They can then be sorted by a maintainer into columns according to their "review" readiness ("Blocked: Work in Progress", "Blocked: Conflict", "Blocked: Tests failing" or "Ready for Review").
+- On review, merge, close etc. they are moved to other columns by automation ("Pending Approval", "Approved, waiting for Merge", "Merged, waiting for Release", "Closed/Abandoned").
 - After release they are manually moved to the "Released" column.
 
 #### Labels

--- a/github-templates.md
+++ b/github-templates.md
@@ -62,7 +62,7 @@ Distributing these templates manually would take quite some time. For that reaso
     folders = Dir.glob('*').select {|f| File.directory? f}
     @source = "../cordova-contribute/.github"
     require 'fileutils'
-    folders.each do |folder| 
+    folders.each do |folder|
         FileUtils.copy_entry @source, "#{folder}/.github"
         Dir.chdir(folder)
         `git add .github`

--- a/testing-releases.md
+++ b/testing-releases.md
@@ -24,7 +24,7 @@ This document describes how to test a release of a Apache Cordova component befo
 
 The code of the component you want to test should be in a folder with the name of the component (e.g. `cordova-plugin-vibration`, `cordova-cli`, `cordova-ios` etc.):
 
-a) Before the release was actually made: The component should be checked out via git.  
+a) Before the release was actually made: The component should be checked out via git.
 b) While the release is in the "Vote" stage and you now want to make sure the archive is good to be able to [vote for it](verify-release-vote.md): Download the `.tgz` source code artifact linked in the `[VOTE]` email on the dev mailing list. Unpack the archive, and move the content of `package` into a folder named after the component, then run `npm install` to install the dependencies.
 
 ### General Testing
@@ -67,7 +67,7 @@ This should start a black-ish app with a "Plugin tests" button. When clicking it
 
 ### Manual Testing
 
-[Plugin Tests](#plugin-tests) most probably do not cover all functionality of a plugin, especially Preferences that can be set via `config.xml` or functionality that was just added to the plugin. Check the `RELEASENOTES.md` file to find out about such functionality and 
+[Plugin Tests](#plugin-tests) most probably do not cover all functionality of a plugin, especially Preferences that can be set via `config.xml` or functionality that was just added to the plugin. Check the `RELEASENOTES.md` file to find out about such functionality and
 
 ```bash
 cd ..
@@ -148,5 +148,5 @@ TODO https://github.com/apache/cordova-coho/blob/master/docs/tools-release-proce
 
 ## Other
 
-TODO https://github.com/apache/cordova-coho/blob/master/docs/tools-release-process.md#test  
+TODO https://github.com/apache/cordova-coho/blob/master/docs/tools-release-process.md#test
 TODO https://github.com/apache/cordova-coho/blob/master/docs/coho-release-process.md#test

--- a/testing.md
+++ b/testing.md
@@ -52,7 +52,7 @@ Cordova projects use several different types of tests:
 
 #### Syntax Checker
 
-- Check if the code of a project follows specific syntax guidelines.  
+- Check if the code of a project follows specific syntax guidelines.
 - Usually uses [`eslint`](https://eslint.org/), which is "a fully pluggable tool for identifying and reporting on patterns in JavaScript".
 
 #### Unit Tests
@@ -134,11 +134,11 @@ TODO Explain: Native code is being execised vs. JS part with all the other test 
 To automate the creating of a test app and the test execution process [`cordova-paramedic`](https://github.com/apache/cordova-paramedic) can be be used:
 
 1. Install `cordova-paramedic` (`npm install -g ...` or clone + `npm install`)
-2. Run Paramedic for the current plugin:  
+2. Run Paramedic for the current plugin:
     ```
-    node /tmp/paramedic/main.js 
-      --config pr/$PLATFORM 
-      --plugin $(pwd) 
+    node /tmp/paramedic/main.js
+      --config pr/$PLATFORM
+      --plugin $(pwd)
     ```
 3. App is built, setup; Tests are run and results reported
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

all

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

I have seen the trailing spaces in multiple Cordova repositories, hope to get them at the source.

### Description
<!-- Describe your changes in detail -->

see title

### Testing
<!-- Please describe in detail how you tested your changes. -->

`git grep ' $'` shows no more trailing spaces

### Checklist

- ~~I've run the tests to see all new and existing tests pass~~
- ~~I added automated test coverage as appropriate for this change~~
- ~~Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)~~
- ~~If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))~~
- [x] I've updated the documentation if necessary
